### PR TITLE
Run full npm install to fetch/cp polyfill

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,5 +9,5 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: '13.x'
-    - run: npm install web-ext
+    - run: npm install
     - run: $(npm bin)/web-ext lint --self-hosted


### PR DESCRIPTION
This is needed to enable the github ci again
since we are manually copying the polyfill it needs to be pulled first