### PR TITLE
Note that jabreHost.py needs to be executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ _Please post any issues or suggestions [here on GitHub](https://github.com/JabRe
 3. Download [org.jabref.jabref.json](https://raw.githubusercontent.com/JabRef/jabref/master/buildres/linux/native-messaging-host/firefox/org.jabref.jabref.json) and put it into 
    - `/usr/lib/mozilla/native-messaging-hosts/org.jabref.jabref.json` to install with admin rights for all users
    - `~/.mozilla/native-messaging-hosts/org.jabref.jabref.json` to install without admin rights for the current user
-4. Ensure that the script `/opt/JabRef/lib/jabrefHost.py` is marked as executable.
+4. Ensure that the script `/opt/jabref/lib/jabrefHost.py` is marked as executable. Check that the capitalization of the path `/opt/jabref/` in `org.jabref.jabref.json` agrees with the path on your system (e.g. installing from the tarball would create `/opt/JabRef/` instead).
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ _Please post any issues or suggestions [here on GitHub](https://github.com/JabRe
 2. Install the JabRef browser extension: [Firefox](https://addons.mozilla.org/en-US/firefox/addon/jabfox?src=external-github).
 <details>
  <summary>Manual installation on Linux (only necessary when you don't use the `deb` file to install/update JabRef)</summary>
- 
+
 3. Download [org.jabref.jabref.json](https://raw.githubusercontent.com/JabRef/jabref/master/buildres/linux/native-messaging-host/firefox/org.jabref.jabref.json) and put it into 
    - `/usr/lib/mozilla/native-messaging-hosts/org.jabref.jabref.json` to install with admin rights for all users
    - `~/.mozilla/native-messaging-hosts/org.jabref.jabref.json` to install without admin rights for the current user
+4. Ensure that the script `/opt/JabRef/lib/jabrefHost.py` is marked as executable.
 
 </details>
 


### PR DESCRIPTION
I installed [jabref-latest](https://aur.archlinux.org/packages/jabref-latest/) via pacman in Arch and then installed the JabFox extension through Mozilla's addon website. The addon would get stuck on `Send to JabRef...` and in Firefox in the JabFox preferences, I would see `Error: Attempt to postMessage on disconnected port`.

I had to make the change indicated in [this PR](https://github.com/JabRef/jabref/pull/5883) and set executable bit of `/opt/JabRef/lib/jabrefHost.py` manually (I noticed this is already the case in the main repo, but it was not in the file installed on my system).

Related to https://github.com/JabRef/JabRef-Browser-Extension/issues/110 and https://github.com/JabRef/JabRef-Browser-Extension/issues/75.
