### PR TITLE
Display better error message for unexpected responses from JabRef

### DIFF
--- a/connector.js
+++ b/connector.js
@@ -138,8 +138,13 @@ Zotero.Connector = new function() {
 					console.error(`JabRef: Error connecting to JabRef: '${response.output}' at '${response.stacktrace}'`);
 					handleError(response.output, '', response.stacktrace)
 				} else {
-					console.error(`JabRef: Error connecting to JabRef: '${response.message}' with details '${response.output}' at '${response.stacktrace}'`);
-					handleError(response.message, response.output, response.stacktrace)
+					if (response.message) {
+						console.error(`JabRef: Error connecting to JabRef: '${response.message}' with details '${response.output}' at '${response.stacktrace}'`);
+						handleError(response.message, response.output, response.stacktrace)
+					} else {
+						console.error("JabRef: Error connecting to JabRef. Unexpected response type", response)
+						handleError("Error connecting to JabRef. Unexpected response type", JSON.stringify(response))
+					}
 				}
 			})
 			.catch(error => {


### PR DESCRIPTION
To diagnose errors such as the one fixed in https://github.com/JabRef/jabref/pull/11047 more quickly next time.

TODO: Test it.