### PR TITLE
Fix Chrome native messaging

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,17 @@ Preparation:
    Opera: `pnpm dev:opera`
    Edge: `pnpm dev:edge`
 
+### Native messaging in local Chrome development
+
+The development build uses the stable Chrome extension ID, so the JabRef native-host manifest already authorizes it. On macOS, if Chrome reports `Specified native messaging host not found.`, refresh the system manifest from the installed JabRef application:
+
+```sh
+sudo cp "/Applications/JabRef.app/Contents/Resources/native-messaging-host/chromium/org.jabref.jabref.json" \
+  "/Library/Google/Chrome/NativeMessagingHosts/org.jabref.jabref.json"
+```
+
+Restart Chrome after updating the manifest. If JabRef is not installed in `/Applications`, update the source path accordingly.
+
 Now just follow the typical steps to [contribute code](https://guides.github.com/activities/contributing-to-open-source/#contributing):
 
 1. Create your feature branch: `git checkout -b my-new-feature`

--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ Normally, you simply install the extension from the browser store and are ready 
 
 Sometimes, a manual installation is necessary (e.g. if you use the portable version of JabRef). In this case, please follow the steps described [in the user manual](https://docs.jabref.org/import-export/import/jabref-browser-extension).
 
+### Troubleshooting native messaging on macOS Chrome
+
+If Chrome reports `Specified native messaging host not found.`, its registered JabRef host manifest may refer to an old location for `jabrefHost.py`. Reinstall the manifest bundled with the currently installed JabRef application:
+
+```sh
+sudo cp "/Applications/JabRef.app/Contents/Resources/native-messaging-host/chromium/org.jabref.jabref.json" \
+  "/Library/Google/Chrome/NativeMessagingHosts/org.jabref.jabref.json"
+```
+
+Quit Chrome completely and reopen it afterwards. This assumes JabRef is installed in `/Applications`; adjust the first path if it is installed elsewhere.
+
 ## Usage
 
 After the installation, you should be able to import bibliographic references into JabRef directly from your browser.

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -200,7 +200,7 @@ export default defineBackground({
       await browser.runtime.sendMessage({ popupClose: "close" });
     }
 
-    function saveAsWebpage(tab) {
+    async function saveAsWebpage(tab) {
       var title = tab.title;
       var url = tab.url;
       var date = new Date().toISOString();
@@ -211,10 +211,10 @@ export default defineBackground({
 		url = {${url}},\
 		urlDate={${date}},\
 		}`;
-      sendBibTexToJabRef(bibtexString);
+      await sendBibTexToJabRef(bibtexString);
     }
 
-    function savePdf(tab) {
+    async function savePdf(tab) {
       var title = tab.title.replace(".pdf", "");
       var url = tab.url;
       var urlEscaped = tab.url.replace(":", "\\:");
@@ -227,7 +227,7 @@ export default defineBackground({
 		url = {${url}},\
 		urlDate={${date}},\
 		}`;
-      sendBibTexToJabRef(bibtexString);
+      await sendBibTexToJabRef(bibtexString);
     }
 
     /*
@@ -294,11 +294,19 @@ export default defineBackground({
     async function onPopupOpened(tab, info) {
       if (!info.translatorsInfo.length) throw new Error("No translator paths provided");
 
-      await browser.tabs.sendMessage(tab.id, {
+      const message = {
         type: "runTranslators",
         url: tab.url,
         translatorsInfo: info.translatorsInfo,
-      });
+      };
+
+      // Chrome runs translators in the offscreen document. Firefox runs them in
+      // the tab's content script.
+      if (browser.offscreen) {
+        await browser.runtime.sendMessage(message);
+      } else {
+        await browser.tabs.sendMessage(tab.id, message);
+      }
     }
 
     async function getConversionMode() {
@@ -353,13 +361,13 @@ export default defineBackground({
 
           if (info && info.isPDF) {
             console.log("JabRef: Export PDF in tab %o", JSON.parse(JSON.stringify(tab)));
-            savePdf(tab);
+            await savePdf(tab);
           } else if (!info.translatorsInfo) {
             console.log(
               "JabRef: No translators, simple saving %o",
               JSON.parse(JSON.stringify(tab)),
             );
-            saveAsWebpage(tab);
+            await saveAsWebpage(tab);
           } else {
             console.log("JabRef: Start translation for tab %o", JSON.parse(JSON.stringify(tab)));
             await onPopupOpened(tab, info);


### PR DESCRIPTION
Fixes https://github.com/JabRef/JabRef-Browser-Extension/issues/616

For Chrome Manifest V3, the background is a service worker and has no DOM. Translators need DOM access, so Chrome uses an offscreen document instead.

